### PR TITLE
docs: add Arduino tutorial links

### DIFF
--- a/docs/embedded-systems/arduino.md
+++ b/docs/embedded-systems/arduino.md
@@ -5,6 +5,12 @@ sidebar_label: Arduino
 ---
 
 ## Beginner
+- [Arduino getting started](https://www.arduino.cc/en/Guide "Arduino getting started")
+- [Robotistan Ardiuno programlama dersleri](https://maker.robotistan.com/kategori/arduino/arduino-programlama/ "Robotistan Ardiuno programlama dersleri")
+- [🎥 Arduino Tarifleri 🎥](https://youtu.be/veJUayf1pxo "Arduino Tarifleri")
+- [🎥 Robotistan Arduino Dersleri ve Projeleri 🎥](https://youtu.be/_2JJ29kmwRU "Arduino Dersleri ve Projeleri")
+- [🎥 Arduino Tutorials | Paul McWhorter 🎥](https://youtu.be/fJWR7dBuc18 "Arduino Tutorials | Paul McWhorter")
+
 
 ## Intermediate
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Source Pocket Contributing Guide: https://github.com/sdtrdev/source-pocket/blob/main/CONTRIBUTING.md
     - 📖 Read the Source Pocket Code of Conduct: https://github.com/sdtrdev/source-pocket/blob/main/CODE_OF_CONDUCT.md
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] Added new link to category
- [ ] New category added
- [ ] Fixed broken link
- [ ] Typo fix
- [ ] Readme update
- [ ] Optimization
- [ ] Documentation update
- [ ] Frontend update

## Description
Arduino hakkında öğretici ve faydalı bulduğum birkaç tane video serisi ve internet sitesi ekledim. Fakat şöyle bir şey benim kafama takıldı. Robotistana ait olan linkleri hiç eklemeseydim daha iyi olurmuydu. Yani sonuçta adamlar kendi ürünlerini satıyolar ve bu reklama girermi.

## [optional] Related Issues & Documents

## [optional] QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes, as well
as any relevant images for UI changes._

## [optional] Anything Else?
